### PR TITLE
Add `fluent-plugin-rewrite-tag-filter` plugin

### DIFF
--- a/fluentd-sumologic/Dockerfile
+++ b/fluentd-sumologic/Dockerfile
@@ -8,6 +8,7 @@ USER root
 RUN apk --no-cache add sudo build-base ruby-dev && \
 
     sudo -u fluent gem install fluent-plugin-sumologic_output && \
+    sudo -u fluent gem install fluent-plugin-rewrite-tag-filter && \
 
     rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && sudo -u fluent gem sources -c && \
     apk del sudo build-base ruby-dev


### PR DESCRIPTION
We need this so that we can edit the tags based on a log event. All
events for Dropwizard arrive with the same tags, however they have a
field we can use in order to parse/handle them differently. For example,
we want to handle HTTP logs differently from DB logs.

We should probably consider renaming this image as it no longer is just
for Sumologic.