### PR TITLE
Specify the version of the base image required

### DIFF
--- a/fluentd-sumologic/Dockerfile
+++ b/fluentd-sumologic/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:latest
+FROM fluent/fluentd:v0.12.34
 MAINTAINER sam.crang@gmail.com
 
 WORKDIR /home/fluent


### PR DESCRIPTION
There are breaking changes with the latest version of the docker image
(`v0.12.35`).